### PR TITLE
chore: bump checkout/setup-node actions to v5

### DIFF
--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
 


### PR DESCRIPTION
Actualiza ctions/checkout y ctions/setup-node de v4 a v5 para evitar warnings por deprecación de Node 20 en runners de GitHub Actions.